### PR TITLE
Raise an exception when trying to flatten out-of-range values to integer types.

### DIFF
--- a/labrad/test/test_types.py
+++ b/labrad/test/test_types.py
@@ -287,7 +287,27 @@ class LabradTypesTests(unittest.TestCase):
             pass
         else:
             raise Exception('Cannot flatten float to value with units')
+    
+    def testNumpySupport(self):
+        """Test flattening and unflattening of numpy arrays"""
+        import numpy as np
+        
+        # TODO: flesh this out with more array types
+        a = np.array([1,2,3,4,5])
+        b = T.unflatten(*T.flatten(a)).asarray
+        self.assertTrue(np.all(a == b))
 
+    def testIntegerRanges(self):
+        """Test flattening of out-of-range integer values"""
+        tests = [
+            (0x80000000, 'i'),
+            (-0x80000001, 'i'),
+            (0x100000000, 'w'),
+            (-1, 'w')
+        ]
+        for n, t in tests:
+            with self.assertRaises(T.FlatteningError):
+                T.flatten(n, t)
 
 if __name__ == "__main__":
     unittest.main()

--- a/labrad/types.py
+++ b/labrad/types.py
@@ -360,7 +360,10 @@ def _flatten_to(obj, types, endianness):
                 foundCompatibleType = True
                 break
         if foundCompatibleType:
-            s, t = t.__flatten__(obj, endianness)
+            try:
+                s, t = t.__flatten__(obj, endianness)
+            except Exception, e:
+                raise FlatteningError(obj, t)
         else:
             # Since we haven't found anything compatible, just try to
             # flatten to any of the suggested types. This covers cases
@@ -564,6 +567,8 @@ class LRInt(LRType, Singleton):
     def __flatten__(self, n, endianness):
         if not isinstance(n, (int, long)):
             raise FlatteningError(n, self)
+        if n >= 0x8000000 or n < -0x80000000:
+            raise ValueError("out of range for type i: {0}".format(n))
         return pack(endianness + 'i', n), self
 
 registerType(int, LRInt())
@@ -581,6 +586,8 @@ class LRWord(LRType, Singleton):
     def __flatten__(self, n, endianness):
         if not isinstance(n, (int, long)):
             raise FlatteningError(n, self)
+        if n > 0xFFFFFFFF or n < 0:
+            raise ValueError("out of range for type w: {0}".format(n))
         return pack(endianness + 'I', n), self
 
 registerType(long, LRWord())


### PR DESCRIPTION
fixes #2 