### PR TITLE
Base DeviceWrapper on object

### DIFF
--- a/labrad/devices.py
+++ b/labrad/devices.py
@@ -34,7 +34,7 @@ class DeviceLockedError(Error):
     # TODO should tell who holds lock and when it expires
     code = 4
 
-class DeviceWrapper:
+class DeviceWrapper(object):
     """A wrapper for a device."""
     def __init__(self, guid, name):
         self.guid = guid # globally-unique identifier


### PR DESCRIPTION
Turns out that you can't use python's ~~`@setting`~~ `@property` decorator on in a class not based on `object` (e.g. "new style classes"). I wanted to do this for the ADR server so I changed the `DeviceWrapper` class. Everything seems to work for the ADR setup--the ADR server, the various GPIB servers, etc. Would anything break if we did this?