### PR TITLE
Make labrad complex arrays unflatten to DimensionlessArray/ValueArray

### DIFF
--- a/labrad/test/test_types.py
+++ b/labrad/test/test_types.py
@@ -128,6 +128,7 @@ class LabradTypesTests(unittest.TestCase):
             # unflatten as ndarray with dtype=int32, we do not put lists
             # in this test.
             U.ValueArray([1, 2, 3], 'm'),
+            U.ValueArray([1j, 2j, 3j], 's'),
             np.array([1, 3, 4], dtype='int32'),
             np.array([1.1, 2.2, 3.3]),
 
@@ -281,7 +282,14 @@ class LabradTypesTests(unittest.TestCase):
         """
         tests = [
             (Value(5.0, 'ft'), ['v[m]'], 'v[ft]'),
-            (U.ValueArray([1, 2, 3], 'm'), ['*v[m]'], '*v[m]')
+
+            # real value array
+            (U.ValueArray([1, 2, 3], ''), [], '*v[]'),
+            (U.ValueArray([1, 2, 3], 'm'), ['*v[m]'], '*v[m]'),
+
+            # complex value array
+            (U.ValueArray([1j, 2j, 3j], ''), [], '*c[]'),
+            (U.ValueArray([1j, 2j, 3j], 'm'), [], '*c[m]')
         ]
         for data, hints, tag in tests:
             self.assertEqual(T.flatten(data, hints)[1], T.parseTypeTag(tag))

--- a/labrad/types.py
+++ b/labrad/types.py
@@ -1069,14 +1069,17 @@ class LRList(LRType):
         elif L.dtype in ['>u4', '<u4']: t = LRWord()
         elif L.dtype in ['>u8', '<u8']: t = LRWord()
         elif L.dtype in ['>f8', '<f8']: t = LRValue('')
-        elif L.dtype in ['>c16', '<c16']: t = LRComplex()
+        elif L.dtype in ['>c16', '<c16']: t = LRComplex('')
         else:
             raise Exception("Can't flatten array of %s" % L.dtype)
         return cls(t, depth=len(L.shape))
 
     @classmethod
     def __lrtype_ValueArray__(cls, L):
-        t = LRValue(str(L.unit))
+        if L[L.unit].dtype in ['>c16', '<c16']:
+            t = LRComplex(L.unit)
+        else:
+            t = LRValue(L.unit)
         return cls(t, depth=len(L._value.shape))
 
     def __le__(self, other):
@@ -1152,7 +1155,7 @@ class LRList(LRType):
         else:
             raise TypeError("Cannot make numpy array with %s"%(elem,))
         a.shape = dims + a.shape[1:] # handle clusters as elements
-        if elem <= LRValue():
+        if elem <= LRValue() or elem <= LRComplex():
             if elem.unit is not None and elem.unit != '':
                 a = U.ValueArray(a, elem.unit)
             else:

--- a/labrad/units.py
+++ b/labrad/units.py
@@ -53,16 +53,9 @@ The version included with LabRAD has been slightly changed:
 """
 
 from math import floor, pi
-#try:
-#    from numpy import array, ndarray
-#    useNumpy = True
-#except ImportError:
-#    array = ndarray = None
-#    useNumpy = False
 
 from labrad import grammar
 import numpy as np
-import fractions
 from fractions import Fraction
 
 # Dictionary containing numbers
@@ -510,12 +503,8 @@ WithUnit._numericTypes[np.ndarray] = ValueArray
 WithUnit._numericTypes[list] = ValueArray
 
 # add support for numeric types returned by most numpy/scipy functions
-try:
-    import numpy
-    WithUnit._numericTypes[numpy.float64] = Value
-    WithUnit._numericTypes[numpy.complex128] = Complex
-except ImportError:
-    pass
+WithUnit._numericTypes[np.float64] = Value
+WithUnit._numericTypes[np.complex128] = Complex
 
 #if useNumpy:
 #    class ValueArray(WithUnit, ndarray):
@@ -990,9 +979,9 @@ class DimensionlessFloat(WithDimensionlessUnit, float):
 WithUnit._dimensionlessTypes[float] = DimensionlessFloat
 WithUnit._dimensionlessTypes[int] = DimensionlessFloat
 WithUnit._dimensionlessTypes[long] = DimensionlessFloat
-WithUnit._dimensionlessTypes[numpy.float64] = DimensionlessFloat
-WithUnit._dimensionlessTypes[numpy.int64] = DimensionlessFloat
-WithUnit._dimensionlessTypes[numpy.float32] = DimensionlessFloat
+WithUnit._dimensionlessTypes[np.float64] = DimensionlessFloat
+WithUnit._dimensionlessTypes[np.int64] = DimensionlessFloat
+WithUnit._dimensionlessTypes[np.float32] = DimensionlessFloat
 WithUnit._numericTypes[DimensionlessFloat] = Value
 
 class DimensionlessComplex(WithDimensionlessUnit, complex):
@@ -1001,7 +990,7 @@ class DimensionlessComplex(WithDimensionlessUnit, complex):
         raise TypeError('DimensionlessComplex not iterable')
 
 WithUnit._dimensionlessTypes[complex] = DimensionlessComplex
-WithUnit._dimensionlessTypes[numpy.complex128] = DimensionlessComplex
+WithUnit._dimensionlessTypes[np.complex128] = DimensionlessComplex
 WithUnit._numericTypes[DimensionlessComplex] = Complex
 
 class DimensionlessArray(WithDimensionlessUnit, np.ndarray):


### PR DESCRIPTION
This allows us to preserve unit information when unflattening complex
arrays, which was previously getting lost when these would be unflattened
as bare numpy ndarrays.

Fixes #64