### PR TITLE
Allow windows-specific command line for running servers with node.

### DIFF
--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -338,7 +338,13 @@ def createGenericServerCls(path, filename, conf):
     cls.isLocal = len(cls.environVars) > 0
 
     # startup
-    cls.cmdline = scp.get('startup', 'cmdline', raw=True)
+    platform_cmdline_option = 'cmdline_{}'.format(sys.platform)
+    if scp.has_option('startup', platform_cmdline_option):
+        # use platform-specific command line
+        cls.cmdline = scp.get('startup', platform_cmdline_option, raw=True)
+    else:
+        # use generic command line
+        cls.cmdline = scp.get('startup', 'cmdline', raw=True)
     cls.path = path
     cls.filename = filename
     try:


### PR DESCRIPTION
For example, servers that have their own start scripts may provide
a windows .bat file in addition to a generic *nix bash script.