### PR TITLE
Mangle setting/server names that conflict with python keywords

### DIFF
--- a/labrad/support.py
+++ b/labrad/support.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 import getpass
 import os
 import socket
+import keyword
 
 from labrad import constants
 
@@ -30,6 +31,8 @@ def mangle(name):
     newname = ''.join(c if c in ALLOWED else '_' for c in name.lower())
     if newname[0] not in FIRST:
         newname = '_' + newname
+    if newname in keyword.kwlist:
+        newname = newname + '_'
     return newname
 
 def indent(s, level=1):


### PR DESCRIPTION
This fixes issue #69 by renaming settings such as del that are keywords.  They are renamed by adding a trailing _, per PEP8.  Dictionary style access (cxn.registry['del']) still works as normal. 