### PR TITLE
Refresh all server/setting wrappers when client connection is refreshed.

### DIFF
--- a/labrad/client.py
+++ b/labrad/client.py
@@ -177,16 +177,18 @@ class HasDynamicAttrs(object):
                                     if p not in self.__attrs]
             for name, pyName, ID in additions:
                 if name in self.__cache:
-                    # pull from cache if possible, but
-                    # tell attribute to refresh itself
+                    # pull from cache if possible
                     s = self.__cache[name]
                     s.ID = ID # update attribute ID
-                    if hasattr(s, 'refresh'):
-                        s.refresh()
                 else:
                     s = self._wrapAttr(self, name, pyName, ID)
                 self.__cache[name] = s
                 self.__attrs[pyName, name, ID] = s
+
+            # refresh all attributes
+            for attr in self.__attrs.values():
+                if hasattr(attr, 'refresh'):
+                    attr.refresh()
 
             self._refreshed = True
         except Exception, e:

--- a/labrad/test/test_refresh.py
+++ b/labrad/test/test_refresh.py
@@ -1,0 +1,75 @@
+import pytest
+
+import labrad
+from labrad import util
+from labrad.server import LabradServer, setting
+
+class RefreshServer1(LabradServer):
+    """First version of the refresh server."""
+
+    name = 'Refresh Test Server'
+
+    @setting(1, returns='s')
+    def greet(self, c):
+        return 'hello!'
+
+    @setting(2, returns='_')
+    def go_away(self, c):
+        pass
+
+class RefreshServer2(LabradServer):
+    """Second version of the refresh server, with different settings."""
+    name = 'Refresh Test Server'
+
+    @setting(1, name='s', returns='s')
+    def greet(self, c, name):
+        return 'hello, {}!'.format(name)
+
+    @setting(2, a='i', b='i', returns='i')
+    def add(self, c, a, b):
+        return a + b
+
+def test_refresh():
+    with labrad.connect() as cxn:
+
+        assert not hasattr(cxn, 'refresh_test_server')
+
+        with util.syncRunServer(RefreshServer1()):
+            cxn.refresh()
+            assert hasattr(cxn, 'refresh_test_server')
+            rts = cxn.refresh_test_server
+
+            assert hasattr(rts, 'greet')
+            assert rts.greet.accepts == ['_']
+            assert rts.greet.returns == ['s']
+
+            assert hasattr(rts, 'go_away')
+            assert rts.go_away.accepts == ['_']
+            assert rts.go_away.returns == ['_']
+
+            assert rts.greet() == 'hello!'
+
+        cxn.refresh()
+        assert not hasattr(cxn, 'refresh_test_server')
+
+        with util.syncRunServer(RefreshServer2()):
+            cxn.refresh()
+            assert hasattr(cxn, 'refresh_test_server')
+
+            # check the old rts we got earlier, as well as the cxn attribute
+            for srv in [rts, cxn.refresh_test_server]:
+                assert hasattr(srv, 'greet')
+                assert srv.greet.accepts == ['s']
+                assert srv.greet.returns == ['s']
+
+                assert hasattr(srv, 'add')
+                assert srv.add.accepts == ['(ii)']
+                assert srv.add.returns == ['i']
+
+                assert not hasattr(srv, 'go_away')
+
+                assert srv.greet('tester') == 'hello, tester!'
+                assert srv.add(100, 101) == 201
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
Previously, only attributes added back from cache or new attributes were
being refreshed, so that for example if a accepted or returned types on an
existing setting were changed and the server restarted, refreshing would
not pick up that change.

Fixes #80