### PR TITLE
Use per-Future queues to get results in synchronous code.

### DIFF
--- a/labrad/backend.py
+++ b/labrad/backend.py
@@ -360,9 +360,8 @@ class Failure(object):
 
 class Future(object):
 
-    ready = Queue.Queue()
-
     def __init__(self):
+        self.ready = Queue.Queue()
         self.done = False
         self.result = None
         self.callbacks = []


### PR DESCRIPTION
Previously, Futures were sharing a single queue, which
sometimes resulted in one request picking up an error
from a different request.