### PR TITLE
Flatten numpy ints to LRInt or LRWord

### DIFF
--- a/labrad/test/test_types.py
+++ b/labrad/test/test_types.py
@@ -313,6 +313,11 @@ class LabradTypesTests(unittest.TestCase):
         a = np.array([1, 2, 3, 4, 5], dtype='int32')
         b = T.unflatten(*T.flatten(a))
         self.assertTrue(np.all(a == b))
+        self.assertTrue(T.flatten(np.int32(5))[0] == '\x00\x00\x00\x05')
+        self.assertTrue(T.flatten(np.int64(-5))[0] == '\xff\xff\xff\xfb')
+        self.assertTrue(len(T.flatten(np.float64(3.15))[0]) == 8)
+        with self.assertRaises(T.FlatteningError):
+            T.flatten(np.int64(-5), T.LRWord())
 
     def testIntegerRanges(self):
         """Test flattening of out-of-range integer values"""

--- a/labrad/types.py
+++ b/labrad/types.py
@@ -578,7 +578,7 @@ class LRInt(LRType, Singleton):
         return unpack(endianness + 'i', s.get(4))[0]
 
     def __flatten__(self, n, endianness):
-        if not isinstance(n, (int, long)):
+        if not isinstance(n, (int, long, np.integer)):
             raise FlatteningError(n, self)
         if n >= 0x80000000 or n < -0x80000000:
             raise ValueError("out of range for type i: {0}".format(n))
@@ -597,7 +597,7 @@ class LRWord(LRType, Singleton):
         return long(unpack(endianness + 'I', s.get(4))[0])
 
     def __flatten__(self, n, endianness):
-        if not isinstance(n, (int, long)):
+        if not isinstance(n, (int, long, np.integer)):
             raise FlatteningError(n, self)
         if n > 0xFFFFFFFF or n < 0:
             raise ValueError("out of range for type w: {0}".format(n))


### PR DESCRIPTION
This is a small fix to allow types.py to correctly flatten numpy integer scalars.  The added tests fail on master